### PR TITLE
Adjust configuration mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,14 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 strict = true
+enable_error_code = [
+    "ignore-without-code",
+    "redundant-expr",
+    "possibly-undefined",
+]
+disallow_any_expr = true
+disallow_any_explicit = true
+
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
The strict flag enables the following flags (the precise list depends on the mypy version, see mypy --help):

  --warn-unused-configs,
  --disallow-any-generics,
  --disallow-subclassing-any,
  --disallow-untyped-calls,
  --disallow-untyped-defs,
  --disallow-incomplete-defs,
  --check-untyped-defs,
  --disallow-untyped-decorators,
  --warn-redundant-casts,
  --warn-unused-ignores,
  --warn-return-any,
  --no-implicit-reexport,
  --strict-equality,
  --extra-checks

This means mypy accepts the following code as valid:

```
import typing

def ignore_without_code() -> int:
    return "a"  # type: ignore

def redundant_expr(x: int) -> int:
    return 1 if isinstance(x, int) else 2

def possible_undefined(x: int) -> int:
    if x > 0:
        result = 1
    return result

def any_explicit(_x: typing.Any) -> None:
    pass

def any_expr() -> None:
    a = x  # type: ignore[name-defined]
```